### PR TITLE
Fix failing tests on Mac M1 chips

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,24 @@
+expect_equal_labels <- function(actual, expected) {
+  actual_features <- split_features(actual)
+  expected_features <- split_features(expected)
+
+  expect_equal(actual_features$mz, expected_features$mz)
+  expect_equal(actual_features$rt, expected_features$rt)
+}
+
+expect_equal_MSdata <- function(actual, expected) {
+  actual_labels <- colnames(actual)
+  expected_labels <- colnames(expected)
+  colnames(actual) <- colnames(expected) <- NULL
+
+  expect_equal_labels(actual_labels, expected_labels)
+  expect_equal(actual, expected)
+}
+
+split_features <- function(labels) {
+  labels <- strsplit(labels, "_")
+  mz_rt_df <- as.data.frame(do.call(rbind, labels))
+  mz_rt_df[, 1] <- as.numeric(mz_rt_df[, 1])
+  mz_rt_df[, 2] <- as.numeric(mz_rt_df[, 2])
+  return(mz_rt_df)
+}

--- a/tests/testthat/test.R
+++ b/tests/testthat/test.R
@@ -23,6 +23,12 @@ test_that("RAMClustR with csv works", {
   actual <- ramclustR(ms = filename, st = 5, maxt = 1, blocksize = 1000)
   actual$history <- NA
   expected$history <- NA
+
+  expect_equal_labels(actual$labels, expected$labels)
+  expect_equal_MSdata(actual$MSdata, expected$MSdata)
+
+  actual$labels <- expected$labels <- actual$MSdata <- expected$MSdata <- NA
+
   expect_equal(actual, expected)
   setwd(wd)
 })


### PR DESCRIPTION
**Problem:** _"RAMClustR with csv works"_ test fails on M1 Mac due to different (from Intel chips) floating numbers handling when computing **mz_rt** features. The difference lies in rounding error; however, no difference is tolerated because the features are stored as strings in the form **mz_rt**.

**Workaround:** **mz_rt** labels are now checked separately from the whole dataset. Each feature label is disassembled into individual **mz** and **rt**, these are then converted to numeric datatypes and checked against their expected values.