### PR TITLE
Fix: properly check if column is already defined

### DIFF
--- a/R/calculate.similarity.R
+++ b/R/calculate.similarity.R
@@ -105,7 +105,7 @@ calculate.similarity <- function(numcols,
     startv <- stopv + 1
     
     # remove column to start next iteration with clean slate
-    rm(column)
+    column <- NULL
   }
   
   cat('\n RAMClust feature similarity matrix calculated and stored.\n')

--- a/R/calculate.similarity.R
+++ b/R/calculate.similarity.R
@@ -31,6 +31,7 @@ calculate.similarity <- function(numcols,
   
   ramclustObj <- vector(mode = "integer", length = vlength)
   block = 1
+  column <- NULL
   
   for (row in 0:(nblocks)) {
     for (col in row:(nblocks)) {
@@ -85,7 +86,7 @@ calculate.similarity <- function(numcols,
       }
       
       # merge computed similarity matrices to single matrix (extend rows)
-      if (exists("column") == FALSE) {
+      if (is.null(column)) {
         column <- sim_matrix
       } else {
         column <- rbind(column, sim_matrix)


### PR DESCRIPTION
This avoids errors when 'column' is already defined outside this function (e.g. by shiny::column())