### PR TITLE
Update xcms metadata retrieval for R4.5.x compatibility

### DIFF
--- a/R/rc.get.xmcs.data.R
+++ b/R/rc.get.xmcs.data.R
@@ -17,7 +17,7 @@
 #' @concept xcms
 #' @export
 getSampleMetadata <- function(xcmsObj) {
-  if (inherits(xcmsObj@phenoData, "NAnnotatedDataFrame")) {
+  if (inherits(xcmsObj@phenoData, "AnnotatedDataFrame")) {
     return(xcmsObj@phenoData@data)
   } else {
     stop("Unsupported phenoData class")


### PR DESCRIPTION
xcms deprecated NAnnotatedDataFrame for >R.4.5.x, so this is a simple fix replacing NAnnotatedDataFrame with AnnotatedDataFrame in rc.get.xcms.data.R