### PR TITLE
keep out.dir optional

### DIFF
--- a/R/do.findmain.R
+++ b/R/do.findmain.R
@@ -68,7 +68,7 @@ do.findmain <- function(
     stop("must supply ramclustObj as input.  i.e. ramclustObj = RC", "\n")
   }
 
-  if(is.null(out.dir)) {
+  if(is.null(out.dir) && (writeMat || writeMS)) {
     stop("please provide a valid output directory")
   }
   


### PR DESCRIPTION
Hello,

Just a very small fix to not having to specify `out.dir` if nothing is written by `do.findmain()`